### PR TITLE
set whitelist of gemservers - because of internal logic of Easy packa…

### DIFF
--- a/xapian-fu.gemspec
+++ b/xapian-fu.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
     '--line-numbers'
 
   s.extra_rdoc_files = ["README.rdoc", "LICENSE", "CHANGELOG.rdoc"]
+  s.allowed_push_host = "https://rubygems.org,https://gems.easysoftware.com"
 
   s.add_development_dependency("rspec", "~> 2.7")
   s.add_development_dependency("rake", "~> 0")


### PR DESCRIPTION
In Easy Redmine - in builder - there Is a condition for check if gem is "our" by gem host server... This "hack" will allow build (pack) gem into ER package...