### PR TITLE
refs #528799 Use copies of terms instead synonyms.

### DIFF
--- a/changelog/fixed_use_copies_of_terms_instead_synonyms_for.md
+++ b/changelog/fixed_use_copies_of_terms_instead_synonyms_for.md
@@ -1,0 +1,1 @@
+* Use copies of terms instead synonyms for diacritics. | [#528799](https://es.easyproject.com/issues/528799) | [@panov.eduard.k](https://git.easy.cz/panov.eduard.k)


### PR DESCRIPTION
Since partial search does not work with synonyms, we replace this mechanic with creating copies of terms.

It also has its drawbacks (positional search not working for this terms and no highlights in snippets), but at least the search works, which is more important.