### PR TITLE
remove development_dependency -> move them into Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
+  gem "rspec", "~> 2.7"
   gem "xapian-ruby", "~> 1.4.9"
 end
+
+gem "pry"
+

--- a/xapian-fu.gemspec
+++ b/xapian-fu.gemspec
@@ -24,12 +24,6 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = ["README.rdoc", "LICENSE", "CHANGELOG.rdoc"]
 
-  s.add_development_dependency("rspec", "~> 2.7")
-  s.add_development_dependency("rake", "~> 0")
-  s.add_development_dependency("irb", "~> 0")
-  s.add_development_dependency("rdoc", "~> 4")
-  s.add_development_dependency("pry")
-
   s.requirements << "libxapian-dev, or the xapian-ruby gem"
   s.required_ruby_version = '>= 2.1.0'
 end


### PR DESCRIPTION
ER core use rspec 3.11+ but because of this development dependency this cause conflict when gems are build.