### PR TITLE
refs #528799 Improve diacritics detection

### DIFF
--- a/changelog/fixed_improve_diacritics_detection.md
+++ b/changelog/fixed_improve_diacritics_detection.md
@@ -1,0 +1,1 @@
+* Improve diacritics detection. | [#528799](https://es.easyproject.com/issues/528799) | [@panov.eduard.k](https://git.easy.cz/panov.eduard.k)

--- a/lib/xapian_fu/xapian_doc.rb
+++ b/lib/xapian_fu/xapian_doc.rb
@@ -374,7 +374,7 @@ module XapianFu #:nodoc:
       if db.process_diacritics
         diacritics = DEFAULT_APPROXIMATIONS.keys.join
         diacritics_terms = xapian_document.terms.select do |t|
-          t.term.force_encoding(Encoding::UTF_8).scan(/\b(?=\w*[#{diacritics}])\p{M}*\p{L}*\w{3,}/).any?
+          t.term.force_encoding(Encoding::UTF_8).scan(/\b(?=\w*[#{diacritics}])\p{M}*\p{L}*/).any?
         end
         diacritics_terms.each do |t|
           term_name = t.term.force_encoding(Encoding::UTF_8)

--- a/spec/xapian_db_spec.rb
+++ b/spec/xapian_db_spec.rb
@@ -638,11 +638,11 @@ describe XapianDb do
       xdb = XapianDb.new(:dir => tmp_dir, :create => true,
                          :fields => [:name], :process_diacritics => true)
 
-      xdb << { name: "nábor" }
+      xdb << { name: "cédéčko" }
       xdb.flush
 
-      xdb.search("nábor").should_not be_empty
-      xdb.search("nabor", synonyms: true).should_not be_empty
+      xdb.search("cédéčko").should_not be_empty
+      xdb.search("cedecko").should_not be_empty
     end
   end
 


### PR DESCRIPTION
Since we are no longer looking for all the words in the text with diacritical characters, but only using terms that have already passed through stemmer and stopper, there is no longer a need for a length limit in regexp.